### PR TITLE
Support for RK3328 MVR9 ir remote

### DIFF
--- a/projects/Rockchip/patches/linux/rockchip-4.4/linux-0005-dts.patch
+++ b/projects/Rockchip/patches/linux/rockchip-4.4/linux-0005-dts.patch
@@ -4603,7 +4603,7 @@ index 000000000000..51d471ba8cef
 +	ir-receiver {
 +		compatible = "gpio-ir-receiver";
 +		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
-+		linux,rc-map-name = "rc-trn9";
++		linux,rc-map-name = "rc-pine64";
 +		pinctrl-0 = <&ir_int>;
 +		pinctrl-names = "default";
 +	};


### PR DESCRIPTION
Support for RK3328 MVR9 1st generation ir remote.